### PR TITLE
fix(ci): declare workflow permissions for ci-workflows@v4

### DIFF
--- a/.github/workflows/build-on-branch.yml
+++ b/.github/workflows/build-on-branch.yml
@@ -3,6 +3,10 @@ name: 'Build'
 on:
   pull_request: {}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check:
     uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v4

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   check:
     uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-check.yml@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
 jobs:
   analyze:
     uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v4

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['*']
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: zenhelix/ci-workflows/.github/workflows/gradle-plugin-release.yml@v4


### PR DESCRIPTION
## Why

Consumer caller workflows inherit the org default `default_workflow_permissions = "read"` (set in `infra/organization.tf:65` on 2026-04-13 as org-hardening). Reusable workflows in `zenhelix/ci-workflows` declare higher permissions internally (e.g. `contents: write` on `create-tag.yml`, `pull-requests: write` on `labeler.yml`). Mismatch → every consumer call produces `startup_failure`:

> The workflow is requesting 'contents: write', but is only allowed 'contents: read'.

## Fix

Declare per-workflow the minimum permissions each call needs. Keeps org-level narrow default intact.

| File | Permissions |
|---|---|
| `build-on-branch.yml` (→ labeler, check) | `contents: write`, `pull-requests: write` |
| `build-on-main.yml` (→ check, create-tag) | `contents: write` |
| `codeql-analysis.yml` (→ codeql) | `security-events: write`, `contents: read`, `actions: read` |
| `release-on-tag.yml` (→ release, publish) | `contents: write` |

Matches the pattern already merged on `zenhelix-ktlint-rules` (pilot).

## Test plan

- [ ] CI reaches execution (no more startup_failure); any remaining failures are pre-existing / unrelated